### PR TITLE
Typo fixed.

### DIFF
--- a/luapstricks.lua
+++ b/luapstricks.lua
@@ -2859,7 +2859,7 @@ systemdict = {kind = 'dict', value = {
       end
       fontdict.FID = fid
     else
-      texio.write_nl'definefont is not implemnted. Pushing dummy font.'
+      texio.write_nl'definefont is not implemented. Pushing dummy font.'
     end
     FontDirectory[fontkey] = raw_fontdict
     push(raw_fontdict)


### PR DESCRIPTION
BTW, the phrase "definefont is not implemented. Pushing dummy font." isn't clearly highlighted. Shouldn't it be a clearly visible warning?